### PR TITLE
Adding support for streaming of NTriple data

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Jakob Voß"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Dist::Milla version v1.0.8, Dist::Zilla version 5.020, CPAN::Meta::Converter version 2.141520",
+   "generated_by" : "Dist::Zilla version 5.031, Dist::Milla version v1.0.5, CPAN::Meta::Converter version 2.142690",
    "license" : [
       "perl_5"
    ],
@@ -31,7 +31,6 @@
       },
       "develop" : {
          "requires" : {
-            "Dist::Milla" : "v1.0.8",
             "Test::Pod" : "1.41"
          }
       },


### PR DESCRIPTION
I need to do Catmandu::Exporter::RDF on big data sets. Currently the exporter creates a memory model first. But in case of NTriples this is not required. A patch has been provided to automatically stream results when the serializer allows for it.