### PR TITLE
Provide caching support for HTTP access

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,13 +4,13 @@
       "Jakob Voß"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Dist::Zilla version 5.036, Dist::Milla version v1.0.15, CPAN::Meta::Converter version 2.150001",
+   "generated_by" : "Dist::Zilla version 5.035, Dist::Milla version v1.0.15, CPAN::Meta::Converter version 2.150001",
    "license" : [
       "perl_5"
    ],
    "meta-spec" : {
       "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
-      "version" : "2"
+      "version" : 2
    },
    "name" : "Catmandu-RDF",
    "no_index" : {
@@ -38,7 +38,7 @@
       "runtime" : {
          "requires" : {
             "Catmandu" : "0.9209",
-            "RDF::LDF" : "0.10",
+            "RDF::LDF" : "0.18",
             "RDF::NS" : "20140910",
             "RDF::Query" : "2.913",
             "RDF::Trine" : "1.013",

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'perl', 'v5.13.1';
 
 requires 'Catmandu', '0.9209';
-requires 'RDF::LDF', '0.10';
+requires 'RDF::LDF', '0.18';
 requires 'RDF::NS', '20140910';
 requires 'RDF::Query', '2.913';
 requires 'RDF::Trine', '1.013';

--- a/lib/Catmandu/Importer/RDF.pm
+++ b/lib/Catmandu/Importer/RDF.pm
@@ -14,6 +14,7 @@ use RDF::LDF;
 use RDF::aREF;
 use RDF::aREF::Encoder;
 use RDF::NS;
+use LWP::UserAgent::CHICaching;
 
 our $VERSION = '0.28';
 
@@ -70,6 +71,31 @@ has predicate_map => (
 has triples => (
     is      => 'ro',
 );
+
+has cache => (
+    is      => 'ro',
+    default => sub { 0 }
+);
+
+has cache_options => (
+    is      => 'ro',
+    default => sub { +{
+        driver => 'Memory', 
+        global => 1 , 
+        max_size => 1024*1024 
+    } }
+);
+
+sub BUILD {
+    my ($self) = @_;
+
+    if ($self->cache) {
+        my $options = $self->cache_options // {};
+        my $cache = CHI->new( %$options );
+        my $ua = LWP::UserAgent::CHICaching->new(cache => $cache);
+        RDF::Trine->default_useragent($ua);
+    }
+}
 
 sub generator {
     my ($self) = @_;
@@ -333,6 +359,26 @@ aREF format, with URIs in C<E<lt>> and C<E<gt>> (no qNames) and literal nodes
 appended by C<@> and optional language code. By default (value C<simple>), all
 RDF nodes are simplfied to their literal form.
 
+=item cache
+
+Set to a true value to cache repeated URL responses in a L<CHI> based backend.
+
+=item cache_options
+
+Provide the L<CHI> based options for caching result sets. By default a memory store of
+1MB size is used.
+
+    use Catmandu;
+
+    my $importer = Catmandu->importer('RDF'
+                                , url => $url
+                                , sparql => $sparql
+                                , cache => 1
+                                , cache_options => {
+                                    driver => 'Memory', 
+                                    global => 1 , 
+                                    max_size => 1024*1024 
+                                });
 =back
 
 =head1 METHODS

--- a/lib/Catmandu/Importer/RDF.pm
+++ b/lib/Catmandu/Importer/RDF.pm
@@ -379,6 +379,7 @@ Provide the L<CHI> based options for caching result sets. By default a memory st
                                     global => 1 , 
                                     max_size => 1024*1024 
                                 });
+
 =back
 
 =head1 METHODS


### PR DESCRIPTION
Support the newest RDF::LDF 0.18 which provides caching functionality for any type of RDF::Trine request (sparql, ldf)