### PR TITLE
fix spelling typo

### DIFF
--- a/lib/Catmandu/Importer/RDF.pm
+++ b/lib/Catmandu/Importer/RDF.pm
@@ -435,7 +435,7 @@ Default configuration options of L<Catmandu::Importer>.
 
 =item sparql
 
-The SPARQL query to be executed on the URL endpoint (currectly only SELECT is
+The SPARQL query to be executed on the URL endpoint (correctly only SELECT is
 supported).  The query can be supplied as string or as filename. The importer
 tries to automatically add missing PREFIX statements from the default namespace
 prefixes.


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Catmandu-RDF.
We thought you might be interested in it too.

    Description: fix spelling typo
    Origin: vendor
    Author: mason james <mtj@kohaaloha.com>
    Last-Update: 2023-02-01
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcatmandu-rdf-perl/raw/master/./debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
